### PR TITLE
fix: Prevent issues where sometimes python2.7 is chosen we can force …

### DIFF
--- a/python/remotivelabs-broker/pyproject.toml
+++ b/python/remotivelabs-broker/pyproject.toml
@@ -49,6 +49,7 @@ Source = "https://github.com/remotivelabs/remotivelabs-apis/tree/main/python/rem
 path = "remotivelabs/broker/__about__.py"
 
 [tool.hatch.envs.default]
+python = "python3"
 dependencies = [
   "pytest-cov~=3.0.0",
   "pytest-pep8~=1.0.6",


### PR DESCRIPTION
…python3 to be used when running hatch

Tested and verified on macos

https://github.com/pypa/hatch/issues/583#issuecomment-1329829289