### PR TITLE
fix: Updated download_file to use the new batch-download api

### DIFF
--- a/python/remotivelabs-broker/remotivelabs/broker/sync/helper.py
+++ b/python/remotivelabs-broker/remotivelabs/broker/sync/helper.py
@@ -179,7 +179,7 @@ def download_file(
     for response in system_stub.BatchDownloadFiles(
         system_api_pb2.FileDescriptions(
             fileDescriptions=[system_api_pb2.FileDescription(path=path.replace(ntpath.sep,
-                                                         posixpath.sep), sha256="xxx")]
+                                                         posixpath.sep))]
         )
     ):
         assert not response.HasField("errorMessage"), (

--- a/python/remotivelabs-broker/remotivelabs/broker/sync/helper.py
+++ b/python/remotivelabs-broker/remotivelabs/broker/sync/helper.py
@@ -176,8 +176,11 @@ def download_file(
     """
 
     file = open(dest_path, "wb")
-    for response in system_stub.DownloadFile(
-        system_api_pb2.FileDescription(path=path.replace(ntpath.sep, posixpath.sep))
+    for response in system_stub.BatchDownloadFiles(
+        system_api_pb2.FileDescriptions(
+            fileDescriptions=[system_api_pb2.FileDescription(path=path.replace(ntpath.sep,
+                                                         posixpath.sep), sha256="xxx")]
+        )
     ):
         assert not response.HasField("errorMessage"), (
             "Error uploading file, message is: %s" % response.errorMessage


### PR DESCRIPTION
QA

Manual qa has been done from the cli, nothing else.
Verified that the file is properly downloaded.

`11:49:10.981 [info] Downloading compressed recording {"configuration/configuration_custom_A/./first_drive_my_can0.meta.json", "configuration/configuration_custom_A/./first_drive_my_can0.raw"}`