### PR TITLE
feat: Added can physical channel name property

### DIFF
--- a/schemas/interfaces_schema.json
+++ b/schemas/interfaces_schema.json
@@ -36,7 +36,10 @@
             "properties": {
               "database": {
                 "$ref": "#/defs/signal_db",
-                "description": "Path to signal database file."
+                "description": "Path to signal database file. Supporting .dbc and .arxml. When using an arxml database one should specify can_physical_channel_name."
+              },
+              "can_physical_channel_name": {
+                "$ref": "#/defs/can_physical_channel_name"
               },
               "device_name": {
                 "description": "Name of device in OS.",
@@ -73,7 +76,10 @@
             "properties": {
               "database": {
                 "$ref": "#/defs/signal_db",
-                "description": "Path to signal database file."
+                "description": "Path to signal database file. Supporting .dbc and .arxml. When using an arxml database one should specify can_physical_channel_name."
+              },
+              "can_physical_channel_name": {
+                "$ref": "#/defs/can_physical_channel_name"
               },
               "device_name": {
                 "description": "Name of device in OS.",
@@ -428,6 +434,10 @@
     "signal_db": {
       "description": "Path to signal database.",
       "type": "string"
+    },
+    "can_physical_channel_name": {
+      "type": "string",
+      "description": "This property is required when using an arxml database. Path to the physical channel that should be used. Referenced by SHORT-NAME element, e.g. /Topology/Name/ID"
     }
   }
 }

--- a/schemas/interfaces_schema.json
+++ b/schemas/interfaces_schema.json
@@ -314,9 +314,13 @@
                   }
                 ]
               },
-              "fibex_file": {
+              "database": {
                 "$ref": "#/defs/signal_db",
                 "description": "Path to Flexray signal database `.xml` file."
+              },
+              "fibex_file": {
+                "$ref": "#/defs/signal_db",
+                "description": "This property is deprecated, use database instead."
               },
               "namespace": {
                 "$ref": "#/defs/namespace"
@@ -332,7 +336,7 @@
               "type",
               "namespace",
               "config",
-              "fibex_file"
+              "database"
             ],
             "title": "Flexray"
           }


### PR DESCRIPTION
### feat: Added can physical channel name property

- This property is used by the signalbroker when it parses an arxml
  signaldatabase
- Clarified the description for database property for can/canfd

### feat: Added database property to flexray type chain

- The signalbroker has since long supported database instead of
  fibex_file
- Keep fibex_file field for backwards compatibility
