### PR TITLE
Schema updates

### DIFF
--- a/schemas/interfaces_schema.json
+++ b/schemas/interfaces_schema.json
@@ -303,11 +303,11 @@
                       "target_config": {
                         "properties": {
                           "interface": {
-                            "describe": "Network interface to use.\nFor example `\"eth0\"`.",
+                            "describe": "Network interface to use.\nFor example `eth0`.",
                             "type": "string"
                           },
                           "multicast": {
-                            "describe": "MAC address to use for multicast.\nFor example `\"01:00:5e:00:00:00\"`.",
+                            "describe": "MAC address to use for multicast.\nFor example `01:00:5e:00:00:00`.",
                             "type": "string"
                           }
                         },
@@ -430,7 +430,7 @@
   ],
   "defs": {
     "host": {
-      "description": "Network address accepted by the OS. Eg. Ipv4: `\"127.0.0.1\"`.",
+      "description": "Network address accepted by the OS. Eg. Ipv4: `127.0.0.1`.",
       "type": "string"
     },
     "namespace": {

--- a/schemas/interfaces_schema.json
+++ b/schemas/interfaces_schema.json
@@ -2,12 +2,8 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "RemotiveBroker configuration",
-  "description": "JSON configuration file for RemotiveBroker. A configuration file must be named `interfaces.json`. Configures all interfaces that the broker will operate on.",
+  "description": "JSON configuration file for RemotiveBroker. The configuration file must be named `interfaces.json` and all paths in the configuration are relative paths to this file.\nConfigures all interfaces that the broker will operate on.",
   "properties": {
-    "node_name": {
-      "description": "Name of the RemotiveBroker node. Required only if the configuration is used in the distributed broker mode.",
-      "type": "string"
-    },
     "chains": {
       "description": "List of configured interfaces available to RemotiveBroker.",
       "items": {
@@ -134,10 +130,11 @@
             "type": "object"
           },
           {
-            "description": "Internal RemotiveLabs protocol for UPD communication over network. Can be used to communicate between RemotiveBrokers.",
+            "description": "CAN-via-UDP protocol. Can be used to communicate between RemotiveBrokers.",
             "properties": {
               "database": {
-                "$ref": "#/defs/signal_db"
+                "$ref": "#/defs/signal_db",
+                "description": "Path to signal database file. Supporting .dbc and .arxml. When using an arxml database one should specify can_physical_channel_name."
               },
               "fixed_payload_size": {
                 "description": "If set, will use this frame size (bytes) for all packets.",
@@ -162,7 +159,7 @@
                 "description": "UDP port for RemotiveBroker to send packets to."
               },
               "type": {
-                "description": "Sets the device type to UDP",
+                "description": "Specifies a CAN-via-UDP interface.",
                 "default": "udp",
                 "enum": [
                   "udp"
@@ -225,7 +222,7 @@
                 ]
               },
               "schedule_autostart": {
-                "description": "Should LIN schedules start at boot? Or paus until user command.",
+                "description": "Should LIN schedules start at boot? Or pause until user command.",
                 "type": "boolean"
               },
               "schedule_file": {
@@ -237,7 +234,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "Sets the device type to LIN",
+                "description": "Specifies a LIN interface.",
                 "default": "lin",
                 "enum": [
                   "lin"
@@ -269,7 +266,7 @@
             "type": "object"
           },
           {
-            "description": "Flexray interface.",
+            "description": "FlexRay interface.",
             "properties": {
               "config": {
                 "oneOf": [
@@ -337,7 +334,7 @@
               },
               "database": {
                 "$ref": "#/defs/signal_db",
-                "description": "Path to Flexray signal database `.xml` file."
+                "description": "Path to FlexRay signal database `.xml` (FIBEX) file."
               },
               "fibex_file": {
                 "$ref": "#/defs/signal_db",
@@ -347,7 +344,7 @@
                 "$ref": "#/defs/namespace"
               },
               "type": {
-                "description": "Sets the device type to Flexray",
+                "description": "Specifies a FlexRay interface.",
                 "default": "flexray",
                 "enum": [
                   "flexray"
@@ -360,12 +357,16 @@
               "config",
               "database"
             ],
-            "title": "Flexray",
+            "title": "FlexRay",
             "type": "object"
           }
         ]
       },
       "type": "array"
+    },
+    "node_name": {
+      "description": "Name of the RemotiveBroker node. Required only if the configuration is used in the distributed broker mode.",
+      "type": "string"
     },
     "grpc_server": {
       "description": "Configuration for build in gRPC server. Documentation for available service is available on <https://docs.remotivelabs.com>.",

--- a/schemas/interfaces_schema.json
+++ b/schemas/interfaces_schema.json
@@ -303,11 +303,11 @@
                       "target_config": {
                         "properties": {
                           "interface": {
-                            "describe": "Network interface to use.\nFor example `eth0`.",
+                            "description": "Network interface to use.\nFor example `eth0`.",
                             "type": "string"
                           },
                           "multicast": {
-                            "describe": "MAC address to use for multicast.\nFor example `01:00:5e:00:00:00`.",
+                            "description": "MAC address to use for multicast.\nFor example `01:00:5e:00:00:00`.",
                             "type": "string"
                           }
                         },
@@ -404,7 +404,7 @@
                   "type": "string"
                 },
                 "exclude": {
-                  "describe": "List of frames to exclude in reflector.",
+                  "description": "List of frames to exclude in reflector.",
                   "type": "array",
                   "items": {
                     "description": "Name of frame to exclude",


### PR DESCRIPTION
### docs[interfaces_schema.json]: Description improvement and typo fix

- Flexray -> FlexRay
- udp is not RemotiveLabs internal
- Put chains on top of the document as this is the most important
    configuration

### docs[interfaces_schema.json]: describe is not a known schema keyword

describe -> description

### docs[interfaces_schema.json]: Avoid including escaped quotes

They don't provide much value and json-schema-for-humans which is used
to generate the schema documentation doesn't handle it well.
