### PR TITLE
Increase max grpc message length

### DIFF
--- a/.github/workflows/python-code-qa-ci.yaml
+++ b/.github/workflows/python-code-qa-ci.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - uses: abatilo/actions-poetry@v2
-      - run: poetry self add 'poethepoet[poetry_plugin]'
+      - run: poetry self add 'poethepoet[poetry_plugin]==0.30.0'
 
       - name: Generate stubs (and build package)
         env:

--- a/.github/workflows/python-code-qa-ci.yaml
+++ b/.github/workflows/python-code-qa-ci.yaml
@@ -19,6 +19,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: 1.8.5
       - run: poetry self add 'poethepoet[poetry_plugin]==0.30.0'
 
       - name: Generate stubs (and build package)

--- a/python/remotivelabs-broker/docker/Dockerfile
+++ b/python/remotivelabs-broker/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
 
 # See https://python-poetry.org/docs/#ci-recommendations
 RUN pip install "poetry==$POETRY_VERSION"
-RUN poetry self add 'poethepoet[poetry_plugin]'
+RUN poetry self add 'poethepoet[poetry_plugin]==0.30.0'
 
 # install the protobuf compiler
 COPY --chmod=0755 docker/download_protoc.sh /tmp/download_protoc.sh

--- a/python/remotivelabs-broker/remotivelabs/broker/__init__.py
+++ b/python/remotivelabs-broker/remotivelabs/broker/__init__.py
@@ -6,8 +6,6 @@ This API uses protobuffer and gRPC stubs directly, available in the submodules:
 - `remotivelabs.broker.common_pb2_grpc`.
 - `remotivelabs.broker.diagnostics_api_pb2`.
 - `remotivelabs.broker.diagnostics_api_pb2_grpc`.
-- `remotivelabs.broker.functional_api_pb2`.
-- `remotivelabs.broker.functional_api_pb2_grpc`.
 - `remotivelabs.broker.network_api_pb2`.
 - `remotivelabs.broker.network_api_pb2_grpc`.
 - `remotivelabs.broker.system_api_pb2`.
@@ -35,8 +33,6 @@ from .generated.sync import (
     common_pb2_grpc,  # noqa: F401
     diagnostics_api_pb2,  # noqa: F401
     diagnostics_api_pb2_grpc,  # noqa: F401
-    functional_api_pb2,  # noqa: F401
-    functional_api_pb2_grpc,  # noqa: F401
     network_api_pb2,  # noqa: F401
     network_api_pb2_grpc,  # noqa: F401
     system_api_pb2,  # noqa: F401

--- a/python/remotivelabs-broker/remotivelabs/broker/sync/__init__.py
+++ b/python/remotivelabs-broker/remotivelabs/broker/sync/__init__.py
@@ -15,8 +15,6 @@ from ..generated.sync import (
     common_pb2_grpc,  # noqa: F401
     diagnostics_api_pb2,  # noqa: F401
     diagnostics_api_pb2_grpc,  # noqa: F401
-    functional_api_pb2,  # noqa: F401
-    functional_api_pb2_grpc,  # noqa: F401
     network_api_pb2,  # noqa: F401
     network_api_pb2_grpc,  # noqa: F401
     system_api_pb2,  # noqa: F401
@@ -70,8 +68,6 @@ __all__ = [
     "common_pb2_grpc",
     "diagnostics_api_pb2",
     "diagnostics_api_pb2_grpc",
-    "functional_api_pb2",
-    "functional_api_pb2_grpc",
     "network_api_pb2",
     "network_api_pb2_grpc",
     "system_api_pb2",

--- a/python/remotivelabs-broker/remotivelabs/broker/sync/client.py
+++ b/python/remotivelabs-broker/remotivelabs/broker/sync/client.py
@@ -153,15 +153,15 @@ class Client:
         self.on_connect: Union[Callable[[Client], None], None] = None
         self.on_signals: Union[Callable[[SignalsInFrame], None], None] = None
 
-    def connect(self, url: str, api_key: Union[str, None] = None):
+    def connect(self, url: str, api_key: Union[str, None] = None, max_message_length: Union[int, None] = None):
         self.url = url
         self.api_key = api_key
         if url.startswith("https"):
             if api_key is None:
                 raise BrokerException("You must supply api-key or access-token to use a cloud broker")
-            self._intercept_channel = br.create_channel(url, self.api_key, None)
+            self._intercept_channel = br.create_channel(url, self.api_key, None, max_message_length)
         else:
-            self._intercept_channel = br.create_channel(url, None, None)
+            self._intercept_channel = br.create_channel(url, None, None, max_message_length)
 
         self._network_stub = network_api_pb2_grpc.NetworkServiceStub(self._intercept_channel)
         self._system_stub = system_api_pb2_grpc.SystemServiceStub(self._intercept_channel)

--- a/rust/remotivelabs-broker/build.rs
+++ b/rust/remotivelabs-broker/build.rs
@@ -5,7 +5,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .compile(
             &[
                 "common.proto",
-                "functional_api.proto",
                 "network_api.proto",
                 "system_api.proto",
                 "traffic_api.proto",

--- a/rust/remotivelabs-broker/examples/sub_client.rs
+++ b/rust/remotivelabs-broker/examples/sub_client.rs
@@ -25,6 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         client_id,
         signals,
         on_change: true,
+        initial_empty: false,
     };
 
     // Read message from stream and print it out

--- a/rust/remotivelabs-broker/examples/subscribe.rs
+++ b/rust/remotivelabs-broker/examples/subscribe.rs
@@ -79,6 +79,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             signal_id: signal_ids,
         }),
         on_change: false,
+        initial_empty: false,
     };
 
     println!("Waiting for signals...");

--- a/rust/remotivelabs-broker/src/lib.rs
+++ b/rust/remotivelabs-broker/src/lib.rs
@@ -4,9 +4,9 @@ use std::{error::Error, fs, path::Path};
 
 use futures::{stream, Stream};
 use generated::base::{
-    file_upload_request::Data, functional_service_client::FunctionalServiceClient,
-    network_service_client::NetworkServiceClient, system_service_client::SystemServiceClient,
-    traffic_service_client::TrafficServiceClient, FileDescription, FileUploadRequest,
+    file_upload_request::Data, network_service_client::NetworkServiceClient,
+    system_service_client::SystemServiceClient, traffic_service_client::TrafficServiceClient,
+    FileDescription, FileUploadRequest,
 };
 use path_slash::PathExt;
 use sha2::{Digest, Sha256};
@@ -82,7 +82,6 @@ pub struct Connection {
     pub system_stub: SystemServiceClient<InterceptedService<Channel, XApiIntercept>>,
     pub network_stub: NetworkServiceClient<InterceptedService<Channel, XApiIntercept>>,
     pub traffic_stub: TrafficServiceClient<InterceptedService<Channel, XApiIntercept>>,
-    pub functional_stub: FunctionalServiceClient<InterceptedService<Channel, XApiIntercept>>,
 }
 
 /// Generate a sha256 key of the data in the provided file
@@ -112,10 +111,6 @@ impl Connection {
                 x_api_key_intercept.clone(),
             ),
             network_stub: NetworkServiceClient::with_interceptor(
-                channel.clone(),
-                x_api_key_intercept.clone(),
-            ),
-            functional_stub: FunctionalServiceClient::with_interceptor(
                 channel.clone(),
                 x_api_key_intercept.clone(),
             ),


### PR DESCRIPTION
Max message length för mottagna meddelande är nu ökad från 4Mb till obegränsad. Det är också möjligt att speca en max-storlek när man öppnar en channel.

För sända meddelande fanns ingen gräns innan. Det är oförändrat.
---
PR:n innehåller lite andra fixar också för att få allting att bygga och för att CI-flödena för python ska fungera.